### PR TITLE
Introduce grace period between page load attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ An `.env` file can be added at the root of the project to define these; simply u
 | PGPORT *                        | Integer  | Postgres database port number                                                                           |
 | PG_DATABASE_CA_CERT             | String   | A base64 encoded CA certificate can be defined in this variable to be used for the postgres connections. |
 | PGSSLROOTCERT                   | String   | If `PG_DATABASE_CA_CERT` is defined, a filepath where the certificate will be stored must be provided in `PGSSLROOTCERT`. |
+| PAGELOAD_MAX_ATTEMPTS           | Integer  | Maximum number of attempts to retry loading a page. (default: `3`)         					           |
+| PAGELOAD_TIMEOUT                | Integer  | Timeout duration for page loads, in milliseconds. (default: `5000`)         					           |
+| PAGELOAD_GRACE_PERIOD           | Integer  | Duration of the grace period between two page load attempt, in milliseconds. (default: `10000`)         |
 | BROWSER_MAX_CONCURRENT_PAGES    | Integer  | Maximum number of pages that can be open at once. (default: `3`)                                        |
 | BROWSER_MAX_CONCURRENT_CONTEXTS | Integer  | Maximum number of browsing contexts that can be open at once. (default: `BROWSER_MAX_CONCURRENT_PAGES`) |
 | MAX_CONCURRENT_SAME_HOST_REQUESTS | Integer  | Maximum number of requests for the same hostname that can be processed at once, shared across however many instances of this service. (default: `10`) |

--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ When a new request comes in, it is analyzed and inserted into a processing queue
 
 Requests have a basic `priority` level: the lower the number, the lower the priority.
 By default, all requests are assigned a priority level of 1, unless a different priority is provided.
-This basic priority system is how free _vs_ premium requests are handled: premium requests have a priority level of 2, and are therefore processed before free requests.
 
-However, the `priority` level is not the only factor in the processing order algorithm. Every _nth_ premium request processed, a free request is processed (**:warning: this has not yet been implemented**).
-This ensures that free users still get reasonable loading times, even if premium users are prioritized. The _nth_ number is defined by an environment variable ([see the Environment variables section](#environment-variables)).
-
-Another factor that is taken into account is server load for the websites that being tested. To prevent overloading others servers,
-no more than 2 requests of the same website will be processed at the same time.
+Server load for the websites that being tested is also taken into account. To prevent overloading others servers,
+no more than X requests of the same website will be processed at the same time. This limit is defined by the 
+`MAX_CONCURRENT_SAME_HOST_REQUESTS` environment variable ([see the Environment variables section](#environment-variables)).
+Server load is also taken into account by allowing a grace period after a page load fails in order to let the
+non-responding server recuperate if it needs to.
 
 Finally, there is one last factor at play in the queue's processing order. If a request has just been completed by a `Processor`,
 that request's URL is provided to the `Queue.next()` method, and the Queue will prioritize other requests on the same page before all others.
-This is to optimize the overall processing time of the web service, as it reduces the total number of page loads that need to be done.
+This is to optimize the overall processing time of the web service, as some tools can run without having to reload the page, therefore 
+reducing the total number of page loads required to test a site. Fewer page loads mean faster testing and fewer resources used on both sides,
+so this is a win-win for everyone involved.
 
 ### The `Processor` and `ProcessorManager`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koalati/tools-service",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koalati/tools-service",
-      "version": "0.1.14",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@koalati/results-validator": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalati/tools-service",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "Web service that handles requests for all website testing on Koalati.",
   "scripts": {
     "start": "node src/server.js",

--- a/src/config.js
+++ b/src/config.js
@@ -10,4 +10,7 @@ module.exports = {
 	WEBHOOK_HOST: process.env.WEBHOOK_HOST || null,
 	WEBHOOK_PATH: process.env.WEBHOOK_PATH || null,
 	SENTRY_DSN: process.env.SENTRY_DSN || null,
+	PAGELOAD_MAX_ATTEMPTS: parseInt(process.env.PAGELOAD_MAX_ATTEMPTS ?? "3"),
+	PAGELOAD_TIMEOUT: parseInt(process.env.PAGELOAD_TIMEOUT ?? "5000"),
+	PAGELOAD_GRACE_PERIOD: parseInt(process.env.PAGELOAD_GRACE_PERIOD ?? "10000"),
 };

--- a/src/utils/queue.js
+++ b/src/utils/queue.js
@@ -149,14 +149,7 @@ class Queue {
 			data.push(currentUrl);
 		}
 
-		/**
-         * @TODO: implement the queue's priority algorithm for premium/regular users.
-         * Higher priority requests should be prioritized (processed first).
-         * However, every N high-priority (2+) requests, X low-priority (1) request should be treated.
-         * The N and X number for the algorithm should be environment variables, so it can be changed easily without issuing new commits.
-         */
 		orderBys.push("priority DESC");
-
 		orderBys.push("received_at ASC");
 
 		// Build and run the actual query

--- a/src/utils/sleep.js
+++ b/src/utils/sleep.js
@@ -1,0 +1,13 @@
+/**
+ * Sleeps for a given duration, then resolves the returned promise.
+ *
+ * @param {int} duration Duration to sleep for (in milliseconds)
+ * @returns Promise
+ */
+function sleep(duration) {
+	return new Promise(resolve => {
+		setTimeout(resolve, duration);
+	});
+}
+
+module.exports = sleep;


### PR DESCRIPTION
Allowing a grace period after a page load fails lets the non-responding server recuperate if it needs to.

This will not only reduce the chances of accidentally DDoSing the servers of the sites being tested, but it will also reduce the chance of incorrect results when the external server returns an error page with an HTTP 2XX response code.